### PR TITLE
Making the launch scripts a little bit more robust.

### DIFF
--- a/bin/genhdr.bat
+++ b/bin/genhdr.bat
@@ -1,1 +1,11 @@
-debug\parasol compiler/main.p %1 %2 --header=parasol/parasol_enums.h compiler/main.p
+setlocal
+
+set BIN=%~dp0
+if "%BIN:~-1%"=="\" set BIN=%BIN:~0,-1%
+
+for %%i in (%BIN%) do set PARASOL_HOME=%%~dpi
+if "%PARASOL_HOME:~-1%"=="\" set PARASOL_HOME=%PARASOL_HOME:~0,-1%
+
+%PARASOL_HOME%\debug\parasol %PARASOL_HOME%\compiler/main.p %1 %2 --header=%PARASOL_HOME%\parasol/parasol_enums.h %PARASOL_HOME%\compiler/main.p
+
+endlocal

--- a/bin/pc.bat
+++ b/bin/pc.bat
@@ -1,1 +1,11 @@
-debug\parasol debug\parasol.pxi %*
+setlocal
+
+set BIN=%~dp0
+if "%BIN:~-1%"=="\" set BIN=%BIN:~0,-1%
+
+for %%i in (%BIN%) do set PARASOL_HOME=%%~dpi
+if "%PARASOL_HOME:~-1%"=="\" set PARASOL_HOME=%PARASOL_HOME:~0,-1%
+
+%PARASOL_HOME%\debug\parasol %PARASOL_HOME%\debug\parasol.pxi %*
+
+endlocal

--- a/bin/regress.cmd
+++ b/bin/regress.cmd
@@ -1,2 +1,12 @@
-bin\pc compiler/main.p --test --compileFromSource %1 %2 %3 test/scripts/parasol_tests.ets >x.out
+setlocal
+
+set BIN=%~dp0
+if "%BIN:~-1%"=="\" set BIN=%BIN:~0,-1%
+
+for %%i in (%BIN%) do set PARASOL_HOME=%%~dpi
+if "%PARASOL_HOME:~-1%"=="\" set PARASOL_HOME=%PARASOL_HOME:~0,-1%
+
+%BIN%\pc %PARASOL_HOME%\compiler/main.p --test --compileFromSource %1 %2 %3 %PARASOL_HOME%\test/scripts/parasol_tests.ets >x.out
 notepad x.out
+
+endlocal

--- a/bin/revert.bat
+++ b/bin/revert.bat
@@ -1,6 +1,14 @@
-copy debug\parasol.pxi.save debug\parasol.pxi
+setlocal
+
+set BIN=%~dp0
+if "%BIN:~-1%"=="\" set BIN=%BIN:~0,-1%
+
+for %%i in (%BIN%) do set PARASOL_HOME=%%~dpi
+if "%PARASOL_HOME:~-1%"=="\" set PARASOL_HOME=%PARASOL_HOME:~0,-1%
+
+copy %PARASOL_HOME%\debug\parasol.pxi.save %PARASOL_HOME%\debug\parasol.pxi
 if errorlevel 1 goto :fail
-del debug\parasol.pxi.save
+del %PARASOL_HOME%\debug\parasol.pxi.save
 if errorlevel 1 goto :fail
 echo SUCCESS
 exit 0

--- a/bin/unit.bat
+++ b/bin/unit.bat
@@ -1,2 +1,11 @@
-debug\parasol debug\parasol.pxi compiler/main.p %2 %3 %4 %5 %6 %7 %8 %9 test/src/%1.p
+setlocal
 
+set BIN=%~dp0
+if "%BIN:~-1%"=="\" set BIN=%BIN:~0,-1%
+
+for %%i in (%BIN%) do set PARASOL_HOME=%%~dpi
+if "%PARASOL_HOME:~-1%"=="\" set PARASOL_HOME=%PARASOL_HOME:~0,-1%
+
+%BIN%\pc %PARASOL_HOME%\compiler/main.p %2 %3 %4 %5 %6 %7 %8 %9 %PARASOL_HOME%\test/src/%1.p
+
+endlocal


### PR DESCRIPTION
They can now be run from anywhere and will detect the Parasol home directory.  I'm having trouble getting Parasol itself to play nicely, so I think there might be some other bugs going on right now.  This means that, for the time being, I am unable to get anything to actually run under Parasol.  As far as this specific change is concerned, my worry there is that things won't play nice with pathnames that alternate between forward and backward slashes.  If that ends up being the case, we'll just need to back this out and I'll fix it up.
